### PR TITLE
Simplify auth to Google-only and add admin route

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -37,6 +37,7 @@ const App = () => (
             <Route path="/privacy" element={<Privacy />} />
             <Route path="/terms" element={<Terms />} />
             <Route path="/admin" element={<Admin />} />
+            <Route path="/super/auth/owner/panel" element={<Admin />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/client/components/MaskedInfoTicker.tsx
+++ b/client/components/MaskedInfoTicker.tsx
@@ -34,7 +34,10 @@ export default function MaskedInfoTicker({
   interval?: number;
   className?: string;
 }) {
-  const list = useMemo(() => (items && items.length ? items : SAMPLE_LINES), [items]);
+  const list = useMemo(
+    () => (items && items.length ? items : SAMPLE_LINES),
+    [items],
+  );
   const index = useCycler(list, interval);
   const lastIndex = useRef(index);
   const direction = useMemo(() => {
@@ -56,9 +59,17 @@ export default function MaskedInfoTicker({
         <AnimatePresence initial={false} mode="wait">
           <motion.div
             key={index}
-            initial={{ x: direction > 0 ? -40 : 40, opacity: 0, rotateY: direction > 0 ? 12 : -12 }}
+            initial={{
+              x: direction > 0 ? -40 : 40,
+              opacity: 0,
+              rotateY: direction > 0 ? 12 : -12,
+            }}
             animate={{ x: 0, opacity: 1, rotateY: 0 }}
-            exit={{ x: direction > 0 ? 40 : -40, opacity: 0, rotateY: direction > 0 ? -12 : 12 }}
+            exit={{
+              x: direction > 0 ? 40 : -40,
+              opacity: 0,
+              rotateY: direction > 0 ? -12 : 12,
+            }}
             transition={{ type: "spring", stiffness: 300, damping: 26 }}
             className="absolute inset-0 flex items-center justify-center text-[13px] md:text-sm font-semibold tracking-wide text-brand-700 dark:text-brand-300"
           >

--- a/client/components/MaskedInfoTicker.tsx
+++ b/client/components/MaskedInfoTicker.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+
+const SAMPLE_LINES = [
+  "Email: j***doe@example.com",
+  "Password: ************",
+  "Phone: +1 *** *** 1234",
+  "IP: 192.***.***.45",
+  "Username: a***_smith",
+  "Card: **** **** **** 1234",
+  "Address: 2** Baker St, L***",
+  "SSN: ***-**-6789",
+  "Token: sk-********************************",
+  "DOB: **/**/1990",
+];
+
+function useCycler<T>(items: T[], intervalMs: number) {
+  const [idx, setIdx] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => {
+      setIdx((i) => (i + 1) % items.length);
+    }, intervalMs);
+    return () => clearInterval(id);
+  }, [items.length, intervalMs]);
+  return idx;
+}
+
+export default function MaskedInfoTicker({
+  items,
+  interval = 2200,
+  className,
+}: {
+  items?: string[];
+  interval?: number;
+  className?: string;
+}) {
+  const list = useMemo(() => (items && items.length ? items : SAMPLE_LINES), [items]);
+  const index = useCycler(list, interval);
+  const lastIndex = useRef(index);
+  const direction = useMemo(() => {
+    const dir = Math.random() > 0.5 ? 1 : -1; // 1: left->right, -1: right->left
+    lastIndex.current = index;
+    return dir;
+  }, [index]);
+
+  return (
+    <div
+      className={
+        "relative mx-auto max-w-xl overflow-hidden rounded-lg border border-border bg-card/70 px-4 py-3 shadow ring-1 ring-brand-500/10 backdrop-blur " +
+        (className || "")
+      }
+      style={{ perspective: 800 }}
+      aria-live="polite"
+    >
+      <div className="relative h-7 md:h-8">
+        <AnimatePresence initial={false} mode="wait">
+          <motion.div
+            key={index}
+            initial={{ x: direction > 0 ? -40 : 40, opacity: 0, rotateY: direction > 0 ? 12 : -12 }}
+            animate={{ x: 0, opacity: 1, rotateY: 0 }}
+            exit={{ x: direction > 0 ? 40 : -40, opacity: 0, rotateY: direction > 0 ? -12 : 12 }}
+            transition={{ type: "spring", stiffness: 300, damping: 26 }}
+            className="absolute inset-0 flex items-center justify-center text-[13px] md:text-sm font-semibold tracking-wide text-brand-700 dark:text-brand-300"
+          >
+            <span className="[text-shadow:0_6px_16px_rgba(79,70,229,0.25)]">
+              {list[index]}
+            </span>
+          </motion.div>
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+}

--- a/client/lib/user.ts
+++ b/client/lib/user.ts
@@ -14,6 +14,7 @@ export type UserProfile = {
   uid: string;
   email: string | null;
   name: string | null;
+  username?: string;
   role?: "user" | "admin";
   uniquePurchaseId: string;
   freeSearches: number;
@@ -28,6 +29,40 @@ function db() {
   return getDbInstance();
 }
 
+function baseFromEmail(email: string) {
+  const local = email.split("@")[0] || "user";
+  const cleaned = local.toLowerCase().replace(/[^a-z0-9]+/g, "");
+  return cleaned || "user";
+}
+
+async function findUniqueUsername(base: string): Promise<string> {
+  const _db = db();
+  let candidate = base;
+  let i = 1;
+  // Check existence by querying username equality
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const q = collection(_db, "users");
+    const { getDocs, where, query, limit } = await import("firebase/firestore");
+    const snap = await getDocs(query(q, where("username", "==", candidate), limit(1)));
+    if (snap.empty) return candidate;
+    i += 1;
+    candidate = `${base}${i}`;
+    if (i > 1000) return `${base}-${cryptoRandomSuffix()}`;
+  }
+}
+
+function cryptoRandomSuffix() {
+  try {
+    const arr = new Uint32Array(1);
+    // @ts-ignore
+    (globalThis.crypto || (window as any).crypto).getRandomValues(arr);
+    return (arr[0] % 100000).toString().padStart(5, "0");
+  } catch {
+    return Math.floor(Math.random() * 100000).toString().padStart(5, "0");
+  }
+}
+
 export async function ensureUserDoc(
   uid: string,
   email: string | null,
@@ -38,10 +73,16 @@ export async function ensureUserDoc(
   const snap = await getDoc(ref);
   if (!snap.exists()) {
     const uniquePurchaseId = uuidv4();
+    let username: string | undefined = undefined;
+    if (email) {
+      const base = baseFromEmail(email);
+      username = await findUniqueUsername(base);
+    }
     const profile: UserProfile = {
       uid,
       email,
       name,
+      username,
       role: "user",
       uniquePurchaseId,
       freeSearches: 3,
@@ -53,6 +94,14 @@ export async function ensureUserDoc(
     };
     await setDoc(ref, profile);
     return profile;
+  } else {
+    const existing = snap.data() as UserProfile;
+    if (!existing.username && email) {
+      const base = baseFromEmail(email);
+      const username = await findUniqueUsername(base);
+      await updateDoc(ref, { username, updatedAt: serverTimestamp() });
+      return { ...existing, username } as UserProfile;
+    }
   }
   return snap.data() as UserProfile;
 }

--- a/client/lib/user.ts
+++ b/client/lib/user.ts
@@ -44,7 +44,9 @@ async function findUniqueUsername(base: string): Promise<string> {
   while (true) {
     const q = collection(_db, "users");
     const { getDocs, where, query, limit } = await import("firebase/firestore");
-    const snap = await getDocs(query(q, where("username", "==", candidate), limit(1)));
+    const snap = await getDocs(
+      query(q, where("username", "==", candidate), limit(1)),
+    );
     if (snap.empty) return candidate;
     i += 1;
     candidate = `${base}${i}`;
@@ -59,7 +61,9 @@ function cryptoRandomSuffix() {
     (globalThis.crypto || (window as any).crypto).getRandomValues(arr);
     return (arr[0] % 100000).toString().padStart(5, "0");
   } catch {
-    return Math.floor(Math.random() * 100000).toString().padStart(5, "0");
+    return Math.floor(Math.random() * 100000)
+      .toString()
+      .padStart(5, "0");
   }
 }
 

--- a/client/pages/Auth.tsx
+++ b/client/pages/Auth.tsx
@@ -4,23 +4,10 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 
 export default function AuthPage() {
-  const { signIn, signUp, signInWithGoogle } = useAuth();
+  const { signInWithGoogle } = useAuth();
   const [mode, setMode] = useState<"signin" | "signup">("signin");
-  const [name, setName] = useState("");
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
 
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    setError(null);
-    try {
-      if (mode === "signin") await signIn(email, password);
-      else await signUp(name, email, password);
-    } catch (err: any) {
-      setError(err?.message ?? "Authentication failed");
-    }
-  }
 
   return (
     <Layout>
@@ -43,75 +30,39 @@ export default function AuthPage() {
             </div>
           </div>
 
-          <form onSubmit={handleSubmit} className="grid gap-4">
-            {mode === "signup" && (
-              <div className="grid gap-2">
-                <label className="text-sm font-medium">Name</label>
-                <input
-                  value={name}
-                  onChange={(e) => setName(e.target.value)}
-                  required
-                  className="rounded-md border border-input bg-background px-3 py-2"
-                />
-              </div>
-            )}
-            <div className="grid gap-2">
-              <label className="text-sm font-medium">Email</label>
-              <input
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                required
-                className="rounded-md border border-input bg-background px-3 py-2"
-              />
-            </div>
-            <div className="grid gap-2">
-              <label className="text-sm font-medium">Password</label>
-              <input
-                type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
-                className="rounded-md border border-input bg-background px-3 py-2"
-              />
-            </div>
-            {error && <p className="text-sm text-red-500">{error}</p>}
-            <Button type="submit" className="w-full">
-              {mode === "signin" ? "Sign in" : "Create account"}
-            </Button>
-          </form>
-
-          <div className="my-4 h-px bg-border" />
-          <Button
-            variant="secondary"
-            className="w-full bg-white text-black hover:opacity-90 border border-border dark:bg-white dark:text-black flex items-center justify-center gap-2"
-            onClick={() => signInWithGoogle()}
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="18"
-              height="18"
-              viewBox="0 0 48 48"
+          {error && <p className="text-sm text-red-500">{error}</p>}
+          <div className="grid gap-4">
+            <Button
+              variant="secondary"
+              className="w-full bg-white text-black hover:opacity-90 border border-border dark:bg-white dark:text-black flex items-center justify-center gap-2"
+              onClick={() => signInWithGoogle()}
             >
-              <path
-                fill="#FFC107"
-                d="M43.611,20.083H42V20H24v8h11.303C33.173,32.659,29.005,36,24,36c-6.627,0-12-5.373-12-12  s5.373-12,12-12c3.059,0,5.842,1.154,7.961,3.039l5.657-5.657C34.046,6.053,29.268,4,24,4C12.955,4,4,12.955,4,24  s8.955,20,20,20s20-8.955,20-20C44,22.659,43.862,21.35,43.611,20.083z"
-              />
-              <path
-                fill="#FF3D00"
-                d="M6.306,14.691l6.571,4.819C14.655,16.041,18.961,13,24,13c3.059,0,5.842,1.154,7.961,3.039l5.657-5.657  C34.046,6.053,29.268,4,24,4C16.318,4,9.656,8.337,6.306,14.691z"
-              />
-              <path
-                fill="#4CAF50"
-                d="M24,44c5.005,0,9.787-1.997,13.303-5.243l-6.146-5.195C29.109,35.091,26.66,36,24,36  c-5.005,0-9.173-3.341-10.651-7.917l-6.571,5.061C9.656,39.663,16.318,44,24,44z"
-              />
-              <path
-                fill="#1976D2"
-                d="M43.611,20.083H42V20H24v8h11.303c-1.083,3.163-3.313,5.658-6.146,7.043l0.001-0.001l6.146,5.195  C33.707,41.637,44,36,44,24C44,22.659,43.862,21.35,43.611,20.083z"
-              />
-            </svg>
-            Continue with Google
-          </Button>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="18"
+                height="18"
+                viewBox="0 0 48 48"
+              >
+                <path
+                  fill="#FFC107"
+                  d="M43.611,20.083H42V20H24v8h11.303C33.173,32.659,29.005,36,24,36c-6.627,0-12-5.373-12-12  s5.373-12,12-12c3.059,0,5.842,1.154,7.961,3.039l5.657-5.657C34.046,6.053,29.268,4,24,4C16.318,4,9.656,8.337,6.306,14.691z"
+                />
+                <path
+                  fill="#FF3D00"
+                  d="M6.306,14.691l6.571,4.819C14.655,16.041,18.961,13,24,13c3.059,0,5.842,1.154,7.961,3.039l5.657-5.657  C34.046,6.053,29.268,4,24,4C16.318,4,9.656,8.337,6.306,14.691z"
+                />
+                <path
+                  fill="#4CAF50"
+                  d="M24,44c5.005,0,9.787-1.997,13.303-5.243l-6.146-5.195C29.109,35.091,26.66,36,24,36  c-5.005,0-9.173-3.341-10.651-7.917l-6.571,5.061C9.656,39.663,16.318,44,24,44z"
+                />
+                <path
+                  fill="#1976D2"
+                  d="M43.611,20.083H42V20H24v8h11.303c-1.083,3.163-3.313,5.658-6.146,7.043l0.001-0.001l6.146,5.195  C33.707,41.637,44,36,44,24C44,22.659,43.862,21.35,43.611,20.083z"
+                />
+              </svg>
+              {mode === "signin" ? "Sign in with Google" : "Sign up with Google"}
+            </Button>
+          </div>
         </div>
       </section>
     </Layout>

--- a/client/pages/Auth.tsx
+++ b/client/pages/Auth.tsx
@@ -8,7 +8,6 @@ export default function AuthPage() {
   const [mode, setMode] = useState<"signin" | "signup">("signin");
   const [error, setError] = useState<string | null>(null);
 
-
   return (
     <Layout>
       <section className="container mx-auto py-12">
@@ -60,7 +59,9 @@ export default function AuthPage() {
                   d="M43.611,20.083H42V20H24v8h11.303c-1.083,3.163-3.313,5.658-6.146,7.043l0.001-0.001l6.146,5.195  C33.707,41.637,44,36,44,24C44,22.659,43.862,21.35,43.611,20.083z"
                 />
               </svg>
-              {mode === "signin" ? "Sign in with Google" : "Sign up with Google"}
+              {mode === "signin"
+                ? "Sign in with Google"
+                : "Sign up with Google"}
             </Button>
           </div>
         </div>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { useNavigate } from "react-router-dom";
 import Layout from "@/components/layout/Layout";
-import MaskedInfoTicker from "@/components/MaskedInfoTicker";
 
 export default function Index() {
   const [query, setQuery] = useState("");
@@ -44,7 +43,6 @@ export default function Index() {
               >
                 Search
               </Button>
-              <MaskedInfoTicker className="mt-2" />
               <p className="text-xs text-foreground/60">
                 1 request/second per IP. Complex queries may take longer.
               </p>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { useNavigate } from "react-router-dom";
 import Layout from "@/components/layout/Layout";
+import MaskedInfoTicker from "@/components/MaskedInfoTicker";
 
 export default function Index() {
   const [query, setQuery] = useState("");
@@ -25,21 +26,25 @@ export default function Index() {
               You can search Phone Numbers, Emails, Full Names, IP addresses,
               Domains, Keywords…
             </p>
+            <p className="mt-2 text-sm text-foreground/60">
+              Privacy-first search. We don’t store queries. Try emails, phones, usernames, IPs, or domains.
+            </p>
             <div className="mt-10 grid gap-4">
               <div className="rounded-2xl border border-border bg-card/80 shadow-lg shadow-brand-500/10 ring-1 ring-brand-500/10 backdrop-blur p-2 md:p-3">
                 <input
                   value={query}
                   onChange={(e) => setQuery(e.target.value)}
                   placeholder="Enter an email, phone, IP, domain, keyword…"
-                  className="w-full rounded-xl bg-transparent px-4 py-5 text-lg outline-none"
+                  className="w-full rounded-xl bg-transparent px-4 py-4 text-lg outline-none"
                 />
               </div>
               <Button
                 onClick={onSearch}
-                className="h-14 text-base rounded-xl hover:scale-[1.02]"
+                className="h-12 text-base rounded-xl hover:scale-[1.02]"
               >
                 Search
               </Button>
+              <MaskedInfoTicker className="mt-2" />
               <p className="text-xs text-foreground/60">
                 1 request/second per IP. Complex queries may take longer.
               </p>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -26,7 +26,8 @@ export default function Index() {
               Domains, Keywords…
             </p>
             <p className="mt-2 text-sm text-foreground/60">
-              Privacy-first search. We don’t store queries. Try emails, phones, usernames, IPs, or domains.
+              Privacy-first search. We don’t store queries. Try emails, phones,
+              usernames, IPs, or domains.
             </p>
             <div className="mt-10 grid gap-4">
               <div className="rounded-2xl border border-border bg-card/80 shadow-lg shadow-brand-500/10 ring-1 ring-brand-500/10 backdrop-blur p-2 md:p-3">


### PR DESCRIPTION
## Purpose

The user requested to streamline the authentication experience by removing all auth options except Google sign-in/sign-up. They also wanted to make the admin panel accessible via a specific route `/super/auth/owner/panel` and requested automatic username generation based on Gmail addresses for new users signing up with Google.

## Code changes

- **Authentication simplification**: Removed email/password form fields and submit handler from Auth page, keeping only Google OAuth button
- **Admin routing**: Added new route `/super/auth/owner/panel` that points to the Admin component
- **Username generation**: Enhanced user profile system to automatically generate unique usernames from email addresses for Google sign-ups
- **UI improvements**: Reduced search bar height from `py-5` to `py-4` and button height from `h-14` to `h-12`
- **Added descriptive text**: Included privacy-focused description below the main search description
- **Created MaskedInfoTicker component**: New animated component that cycles through masked personal information examples (emails, passwords, etc.) with 3D sliding animations from left-to-right or right-to-leftTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ef266ba190504a5ab027ce74038f49a8/pulse-home)

👀 [Preview Link](https://ef266ba190504a5ab027ce74038f49a8-pulse-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ef266ba190504a5ab027ce74038f49a8</projectId>-->
<!--<branchName>pulse-home</branchName>-->